### PR TITLE
support sentry APM

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ framework.
   - [Manage prometheus-http-sd by systemd](#manage-prometheus-http-sd-by-systemd)
   - [Admin Page](#admin-page)
   - [Serve under a different root path](#serve-under-a-different-root-path)
+  - [Sentry APM](#sentry-apm)
 - [Define your targets](#define-your-targets)
   - [Your target generator](#your-target-generator)
   - [The Target Path](#the-target-path)
@@ -40,6 +41,7 @@ framework.
 - Auto reload when generator or targets changed;
 - Support managing targets in a hierarchy way;
 - Throttle parallel execution and cache the result for Python script;
+- Support Sentry APM.
 
 ## Installation
 
@@ -205,6 +207,13 @@ location /http_sd/ {
 Then you need to tell prometheus_http_sd to serve all HTTP requests under this
 path, by using the `--url_prefix /http_sd` cli option, (or `-r /http_sd` for
 short).
+
+### Sentry APM
+
+You can use the option `--sentry-url <you-sentry-url>` (or `-s <your-sentry-url>`)
+to enable Sentry APM.
+
+The Exception from user's script will be sent to Sentry.
 
 ## Define your targets
 

--- a/prometheus_http_sd/cli.py
+++ b/prometheus_http_sd/cli.py
@@ -62,14 +62,40 @@ def main(log_level):
     is_flag=True,
     help="Enable memory tracer, will print it into logs",
 )
+@click.option(
+    "--sentry-url",
+    "-s",
+    help=(
+        "Using sentry AMP(sentry.io) You need to manually pip install"
+        " sentry-sdk"
+    ),
+)
 def serve(
-    host, port, connection_limit, threads, url_prefix, root_dir, enable_tracer
+    host,
+    port,
+    connection_limit,
+    threads,
+    url_prefix,
+    root_dir,
+    enable_tracer,
+    sentry_url,
 ):
     config.root_dir = root_dir
     app = create_app(url_prefix)
 
     if enable_tracer:
         start_tracing_thread()
+
+    if sentry_url:
+        try:
+            import sentry_sdk
+        except ImportError:
+            print("import sentry_sdk failed, please pip install sentry-sdk")
+            sys.exit(2)
+
+        sentry_sdk.init(sentry_url)
+        print("sentry sdk initialized!")
+
     waitress.serve(
         app,
         host=host,

--- a/prometheus_http_sd/decorator.py
+++ b/prometheus_http_sd/decorator.py
@@ -154,10 +154,13 @@ class TimeoutDecorator:
                 "response": None,
                 "traceback": [],
                 "expired_timestamp": float("inf"),
+                "raw_exception": None,
+                "raised_raw": False,
             }
 
             def target_function(key):
                 try:
+                    print("running target function")
                     cache["response"] = function(*arg, **kwargs)
                     cache["expired_timestamp"] = time.time() + self.cache_time
                 except Exception as e:
@@ -167,8 +170,9 @@ class TimeoutDecorator:
                         "traceback": traceback.format_tb(e.__traceback__),
                     }
                     cache["expired_timestamp"] = 0
+                    cache["raw_exception"] = e
+                    cache["raised_raw"] = False
 
-                    raise e
                 with self.heap_lock:
                     heapq.heappush(
                         self.heap,
@@ -213,13 +217,21 @@ class TimeoutDecorator:
             if cache["thread"].is_alive():
                 raise TimeoutException("target function timeout!")
             if cache["error"]:
-                e = cache["error"]
-                # avoid duplicated append the traceback
-                raise CachedScriptException(
-                    e["message"],
-                    e["error_type"],
-                    e["traceback"],
-                )
+                print("cache: %s", cache)
+                print("cache id: %s", id(cache))
+                print("thread cache: %s", self.thread_cache)
+                if not cache["raised_raw"]:
+                    cache["raised_raw"] = True
+                    print("cache: %s", cache)
+                    raise cache["raw_exception"]
+                else:
+                    e = cache["error"]
+                    # avoid duplicated append the traceback
+                    raise CachedScriptException(
+                        e["message"],
+                        e["error_type"],
+                        e["traceback"],
+                    )
             return cache["response"]
 
         return wrapper

--- a/prometheus_http_sd/decorator.py
+++ b/prometheus_http_sd/decorator.py
@@ -30,7 +30,7 @@ _collection_run_interval = Histogram(
 )
 
 
-class WrapTargetException(Exception):
+class CachedScriptException(Exception):
     """Raised when user's function raises an exception."""
 
     def __init__(self, message, exception_type="Exception", traceback=[]):
@@ -167,6 +167,8 @@ class TimeoutDecorator:
                         "traceback": traceback.format_tb(e.__traceback__),
                     }
                     cache["expired_timestamp"] = 0
+
+                    raise e
                 with self.heap_lock:
                     heapq.heappush(
                         self.heap,
@@ -213,7 +215,7 @@ class TimeoutDecorator:
             if cache["error"]:
                 e = cache["error"]
                 # avoid duplicated append the traceback
-                raise WrapTargetException(
+                raise CachedScriptException(
                     e["message"],
                     e["error_type"],
                     e["traceback"],

--- a/test/app_root/error/error.py
+++ b/test/app_root/error/error.py
@@ -1,5 +1,3 @@
 def generate_targets(**args):
     """Return arg list in label target."""
-    a = 1
-    b = "foo"
     return 1 / 0

--- a/test/app_root/error/error.py
+++ b/test/app_root/error/error.py
@@ -1,0 +1,3 @@
+def generate_targets(**args):
+    """Return arg list in label target."""
+    return 1 / 0

--- a/test/app_root/error/error.py
+++ b/test/app_root/error/error.py
@@ -1,3 +1,5 @@
 def generate_targets(**args):
     """Return arg list in label target."""
+    a = 1
+    b = "foo"
     return 1 / 0


### PR DESCRIPTION

changes:

- When user's exception happened first time (not cached), raise the raw Exception. So that sentry SDK can inspect the 
- rename exception to `CachedScriptException` to indicate this is a cached exception, not a real one.